### PR TITLE
Fix a false package got outdated error caused by line endings

### DIFF
--- a/.github/workflows/zlib.yml
+++ b/.github/workflows/zlib.yml
@@ -74,6 +74,9 @@ jobs:
             xcode_version: '11.3.1'
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Configure git
+        run: git config --global core.autocrlf input
+        shell: bash
       - name: Checkout
         uses: actions/checkout@v2
         with:
@@ -90,7 +93,6 @@ jobs:
           compiler: ${{ matrix.compiler }}
           compiler-versions: ${{ matrix.compiler_version }}
           docker-images: ${{ matrix.docker_image }}
-          lf-endings: true
         env:
           CONAN_VISUAL_RUNTIMES: ${{ matrix.vs_runtimes }}
           CONAN_ARCHS: ${{ matrix.archs }}


### PR DESCRIPTION
This is caused due to different line endings in Windows and Linux/macOS.
This happens when Windows uploads it with CRLF while Linux/macOS do it with only LF.

See https://docs.conan.io/en/latest/faq/using.html?highlight=crlf#packages-got-outdated-when-uploading-an-unchanged-recipe-from-a-different-machine

